### PR TITLE
Fixed bug where NSubstitute.Tests<T> created the SUT as a mock

### DIFF
--- a/Examples/FullSUTMock.cs
+++ b/Examples/FullSUTMock.cs
@@ -5,16 +5,16 @@
     using NSubstitute;
     using Xunit;
 
-    public interface IPartialMockService
+    public interface IFullMockService
     {
         string GetValue(Guid id);
     }
 
-    public class PartialMock
+    public class FullSUTMock
     {
-        private readonly IPartialMockService _service;
+        private readonly IFullMockService _service;
 
-        public PartialMock(IPartialMockService service)
+        public FullSUTMock(IFullMockService service)
         {
             _service = service;
         }
@@ -37,14 +37,14 @@
 
         protected internal virtual string GetValueEx(Guid id)
         {
-            return _service.GetValue(id);
+            throw new NotImplementedException();
         }
     }
 
-    public class PartialMockTests : TestsPartOf<PartialMock>
+    public class FullMockTests : TestsSubstituteOf<FullSUTMock>
     {
         [Fact]
-        public void MethodIsNotSubbed_OriginalImplementationGotCalled()
+        public void MethodIsNotSubbed_OriginalImplementationWasNotCalled()
         {
             var id = Guid.NewGuid();
             var wrapper = new Wrapper();
@@ -53,7 +53,7 @@
 
             var actual = SUT.GetValue(id);
 
-            actual.Should().Be(id.ToString());
+            actual.Should().BeNullOrWhiteSpace();
         }
 
         [Fact]
@@ -71,7 +71,7 @@
             actual.Should().Be("42");
         }
 
-        private class Wrapper : IPartialMockService
+        private class Wrapper : IFullMockService
         {
             public string GetValue(Guid id)
             {

--- a/Examples/PartialSUTMock.cs
+++ b/Examples/PartialSUTMock.cs
@@ -1,0 +1,82 @@
+﻿namespace Examples
+{
+    using System;
+    using FluentAssertions;
+    using NSubstitute;
+    using Xunit;
+
+    public interface IPartialMockService
+    {
+        string GetValue(Guid id);
+    }
+
+    public class PartialSUTMock
+    {
+        private readonly IPartialMockService _service;
+
+        public PartialSUTMock(IPartialMockService service)
+        {
+            _service = service;
+        }
+
+        public string GetValue(Guid id)
+        {
+            // Here we would like to make sure that we're able to stub other virtual methods of the same class.
+            // We wanna be sure that we get a partial mock which is useful for checking a scenario
+            // in which a method knows an algorithm. It doesn't know any lower level details
+            // it just does something according to some algorithm.
+            // In that algorithm it may call other services which were injected and we can stub(we're not concerned about those here)
+            // it also may call some other members of this class which could be virtual or quite often they're
+            // "protected virtual internal" those methods just may do some low level things so that our algorithm
+            // looks nice and clean.
+            // 
+            // In this particular example the algorithm is pretty dumb it just delegates call to GetValueEx
+            // We would like be able to stub completely the call if we wish.
+            return GetValueEx(id);
+        }
+
+        protected internal virtual string GetValueEx(Guid id)
+        {
+            return _service.GetValue(id);
+        }
+    }
+
+    public class PartialMockTests : TestsPartOf<PartialSUTMock>
+    {
+        [Fact]
+        public void MethodIsNotSubbed_OriginalImplementationGotCalled()
+        {
+            var id = Guid.NewGuid();
+            var wrapper = new Wrapper();
+
+            Use(wrapper);
+
+            var actual = SUT.GetValue(id);
+
+            actual.Should().Be(id.ToString());
+        }
+
+        [Fact]
+        public void MethodIsSubbed_TheValueWhichWasSetOnStubbedIsReturned()
+        {
+            var id = Guid.NewGuid();
+            var wrapper = new Wrapper();
+
+            Use(wrapper);
+
+            SUT.GetValueEx(id).Returns("42");
+
+            var actual = SUT.GetValue(id);
+
+            actual.Should().Be("42");
+        }
+
+        private class Wrapper : IPartialMockService
+        {
+            public string GetValue(Guid id)
+            {
+                return id.ToString();
+            }
+        }
+    }
+}

--- a/Neovolve.Streamline.NSubstitute.UnitTests/TestsSubstituteOfTests.cs
+++ b/Neovolve.Streamline.NSubstitute.UnitTests/TestsSubstituteOfTests.cs
@@ -1,0 +1,25 @@
+namespace Neovolve.Streamline.NSubstitute.UnitTests
+{
+    using System;
+    using FluentAssertions;
+    using global::NSubstitute;
+    using Xunit;
+
+    public class TestsSubstituteOfTests
+    {
+        [Fact]
+        public void CanSubstituteVirtualMethod()
+        {
+            var id = Guid.NewGuid();
+            var expected = Guid.NewGuid().ToString();
+
+            var wrapper = new TestsSubstituteOfWrapper<TypeWithDependency>();
+
+            wrapper.SUT.GetValueFromService(id).Returns(expected);
+
+            var actual = wrapper.SUT.GetValue(id);
+
+            actual.Should().Be(expected);
+        }
+    }
+}

--- a/Neovolve.Streamline.NSubstitute.UnitTests/TestsSubstituteOfWrapper.cs
+++ b/Neovolve.Streamline.NSubstitute.UnitTests/TestsSubstituteOfWrapper.cs
@@ -1,0 +1,11 @@
+namespace Neovolve.Streamline.NSubstitute.UnitTests
+{
+    using global::NSubstitute;
+
+    public class TestsSubstituteOfWrapper<T> : TestsSubstituteOf<T> where T : class
+    {
+        public TestsSubstituteOfWrapper(params object[] values) : base(values)
+        {
+        }
+    }
+}

--- a/Neovolve.Streamline.NSubstitute.UnitTests/TypeWithDependency.cs
+++ b/Neovolve.Streamline.NSubstitute.UnitTests/TypeWithDependency.cs
@@ -13,6 +13,11 @@ namespace Neovolve.Streamline.NSubstitute.UnitTests
 
         public string GetValue(Guid id)
         {
+            return GetValueFromService(id);
+        }
+
+        public virtual string GetValueFromService(Guid id)
+        {
             return _service.GetValue(id);
         }
     }

--- a/Neovolve.Streamline.NSubstitute/Tests.cs
+++ b/Neovolve.Streamline.NSubstitute/Tests.cs
@@ -1,27 +1,19 @@
 ﻿namespace NSubstitute
 {
     using System;
-    using System.Reflection;
 
     public abstract class Tests<T> : Neovolve.Streamline.Tests<T> where T : class
     {
         protected Tests(params object[] services) : base(services)
         {
         }
-        
+
         protected override object BuildService(Type type, string key)
         {
-            var types = new[] { type };
+            var types = new[] {type};
             var parameters = Array.Empty<object>();
 
             return Substitute.For(types, parameters);
-        }
-
-        protected override T BuildSUT(ConstructorInfo constructor, object[] parameterValues)
-        {
-            Type[] types = { TargetType };
-
-            return (T)Substitute.For(types, parameterValues);
         }
     }
 }

--- a/Neovolve.Streamline.NSubstitute/TestsPartOf.cs
+++ b/Neovolve.Streamline.NSubstitute/TestsPartOf.cs
@@ -1,20 +1,11 @@
 ﻿namespace NSubstitute
 {
-    using System;
     using System.Reflection;
 
-    public abstract class TestsPartOf<T> : Neovolve.Streamline.Tests<T> where T : class
+    public abstract class TestsPartOf<T> : Tests<T> where T : class
     {
         protected TestsPartOf(params object[] services) : base(services)
         {
-        }
-
-        protected override object BuildService(Type type, string key)
-        {
-            var types = new[] { type };
-            var parameters = Array.Empty<object>();
-
-            return Substitute.For(types, parameters);
         }
 
         protected override T BuildSUT(ConstructorInfo constructor, object[] parameterValues)

--- a/Neovolve.Streamline.NSubstitute/TestsSubstituteOf.cs
+++ b/Neovolve.Streamline.NSubstitute/TestsSubstituteOf.cs
@@ -1,0 +1,19 @@
+﻿namespace NSubstitute
+{
+    using System;
+    using System.Reflection;
+
+    public abstract class TestsSubstituteOf<T> : Tests<T> where T : class
+    {
+        protected TestsSubstituteOf(params object[] services) : base(services)
+        {
+        }
+        
+        protected override T BuildSUT(ConstructorInfo constructor, object[] parameterValues)
+        {
+            Type[] types = { TargetType };
+
+            return (T)Substitute.For(types, parameterValues);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ This package brings several advantages.
  - The SUT instance is automatically created with any required service dependencies
  - Adding, removing or re-ordering constructor parameters have limited or no impact on existing unit tests
 
-## Examples
+## Examples using NSubstitute
 
 [SUT with multiple parameters](Examples/MultipleParameters.cs)  
 [SUT with single parameter](Examples/SingleParameter.cs)  
@@ -121,7 +121,8 @@ This package brings several advantages.
 [SUT declared as internal having public interface](Examples/InternalTypePublicInterface.cs)  
 [SUT declared as internal via proxy](Examples/InternalScopedTypes.cs)  
 [Using test class constructor parameters](Examples/TestClassConstructorParameters.cs)  
-[SUT as partial mock](Examples/PartialMock.cs)  
+[SUT as partial mock](Examples/PartialSUTMock.cs)  
+[SUT as full mock](Examples/FullSUTMock.cs)  
 
 ## Supporters
 


### PR DESCRIPTION
Fixed bug where NSubstitute.Tests<T> created the SUT as a mock instead of an instance of the type

Added TestsSubstituteOf to support this use case